### PR TITLE
Prevent image overflow on guide preview

### DIFF
--- a/packages/react-components/src/components/ProductGuidePreview.tsx
+++ b/packages/react-components/src/components/ProductGuidePreview.tsx
@@ -6,39 +6,46 @@ import Link from 'next/link';
 import { GuidePreviewBlock } from 'core/domain/pageBlock';
 
 const ProductGuidePreview = (props: GuidePreviewBlock) => (
-  <Card raised sx={{ display: 'flex' }}>
-    <CardContent sx={{ flex: '1 0 auto' }}>
-      <Stack spacing={2} justifyContent='center' alignItems='flex-start'>
-        <Typography variant='h6' color='text.primary'>
-          {props.title}
-        </Typography>
-        <Typography variant='subtitle2' component='div' color='text.primary'>
-          {props.preview.title}
-        </Typography>
-        <Typography variant='body2' color='text.primary' component='div'>
-          <ul>
-            {props.preview.description.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </Typography>
-        <ButtonNaked
-          size='medium'
-          color='primary'
-          href={props.preview.link}
-          endIcon={<ArrowForwardIcon />}
-          component={Link}
-        >
-          {'Scopri'}
-        </ButtonNaked>
-      </Stack>
-    </CardContent>
-    <CardMedia
-      component='img'
-      sx={{ width: 350 }}
-      image={props.preview.image.src}
-      alt={props.preview.image.alt}
-    />
+  <Card raised>
+    <Stack
+      direction='row'
+      justifyContent='space-between'
+      alignItems='stretch'
+      spacing={2}
+    >
+      <CardContent>
+        <Stack spacing={2} justifyContent='center' alignItems='flex-start'>
+          <Typography variant='h6' color='text.primary'>
+            {props.title}
+          </Typography>
+          <Typography variant='subtitle2' component='div' color='text.primary'>
+            {props.preview.title}
+          </Typography>
+          <Typography variant='body2' color='text.primary' component='div'>
+            <ul>
+              {props.preview.description.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </Typography>
+          <ButtonNaked
+            size='medium'
+            color='primary'
+            href={props.preview.link}
+            endIcon={<ArrowForwardIcon />}
+            component={Link}
+          >
+            {'Scopri'}
+          </ButtonNaked>
+        </Stack>
+      </CardContent>
+      <CardMedia
+        component='img'
+        sx={{ width: 350 }}
+        image={props.preview.image.src}
+        alt={props.preview.image.alt}
+      />
+    </Stack>
   </Card>
 );
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevent overflow of the image when the test is too long:
![Screenshot 2023-05-23 at 09 49 49](https://github.com/pagopa/developer-portal/assets/4775679/68654dcf-d39e-4907-8ab6-ee5e449af939)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally

#### Screenshots (if appropriate):
![Screenshot 2023-05-23 at 09 48 16](https://github.com/pagopa/developer-portal/assets/4775679/ae93bdd5-f7d4-4d11-a738-d7d103010981)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
