### PR TITLE
[DEV-726] - Fix guide cards text margin, padding and list line-height

### DIFF
--- a/apps/nextjs-website/src/components/atoms/UnorderedList/UnorderedList.module.css
+++ b/apps/nextjs-website/src/components/atoms/UnorderedList/UnorderedList.module.css
@@ -1,3 +1,6 @@
 .UnorderedList {
   list-style-type: square;
+  line-height: 28px;
+  margin: 8px 0 0 0;
+  padding-left: 26px;
 }

--- a/apps/nextjs-website/src/components/molecules/GuideCard/GuideCard.tsx
+++ b/apps/nextjs-website/src/components/molecules/GuideCard/GuideCard.tsx
@@ -74,6 +74,10 @@ export const GuideCard: FC<GuideCardProps> = ({
               flexDirection: 'column',
               flexGrow: 1,
               justifyContent: 'space-between',
+              padding: '40px',
+              '&:last-child': {
+                paddingBottom: '40px',
+              },
             }}
           >
             <Box>


### PR DESCRIPTION
#### List of Changes
- Fix guide cards text margin, padding and list line-height

#### Motivation and Context

#### How Has This Been Tested?
Manually

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/developer-portal/assets/39835990/c85ffd9c-dfcd-4afc-9b01-fc7c090c372a)

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
