### PR TITLE
Fix icon for pagoPA API page

### DIFF
--- a/apps/nextjs-website/src/components/molecules/ApiSection/ApiSection.tsx
+++ b/apps/nextjs-website/src/components/molecules/ApiSection/ApiSection.tsx
@@ -12,6 +12,7 @@ import { Product } from '@/lib/types/product';
 import { styles } from '@/components/molecules/ApiSection/ApiSection.styles';
 import Link from 'next/link';
 import { ButtonNaked } from '@pagopa/mui-italia';
+import IconWrapper from '@/components/atoms/IconWrapper/IconWrapper';
 
 export type ApiPageProps = {
   readonly product: Product;
@@ -89,7 +90,9 @@ const ApiSection = ({ product, specURLs, soapDocumentation }: ApiPageProps) => {
               aria-label={soapDocumentation.buttonLabel}
               href={soapDocumentation.url}
               title={soapDocumentation.buttonLabel}
-              endIcon={soapDocumentation.icon}
+              endIcon={
+                <IconWrapper icon={soapDocumentation.icon} color={textColor} />
+              }
             >
               {soapDocumentation.buttonLabel}
             </ButtonNaked>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The icon next to "Vai a GitHub" is not rendered.

#### List of Changes
<!--- Describe your changes in detail -->
Pass the icon to the component `ButtonNaked` using the `IconWrapper`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to render the icon

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
Before the fix:
<img width="1605" alt="Screenshot 2023-07-12 at 16 40 48" src="https://github.com/pagopa/developer-portal/assets/9998393/93b290fa-47d9-4578-81e7-6f239510d632">

After the fix:
<img width="1605" alt="Screenshot 2023-07-12 at 16 41 09" src="https://github.com/pagopa/developer-portal/assets/9998393/638b4e3d-34e3-49aa-8ae8-955595e3fd87">

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
