### PR TITLE
Remove Next export using next build command

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -49,13 +49,6 @@ runs:
       shell: bash
       run: npm run build -w nextjs-website
 
-    - name: Export static website
-      env:
-        ENVIRONMENT: ${{ inputs.environment }}
-        PATH_TO_GITBOOK_DOCS: ${{ inputs.path_to_gitbook_docs }}
-      shell: bash
-      run: npm run export -w nextjs-website
-
     - name: Configure AWS Credentials
       env:
         AWS_REGION: eu-south-1

--- a/apps/nextjs-website/next.config.js
+++ b/apps/nextjs-website/next.config.js
@@ -11,8 +11,9 @@ const nextConfig = {
   transpilePackages: [
     '@pagopa/pagopa-editorial-components',
     '@pagopa/mui-italia',
-    '@mui/material'
+    '@mui/material',
   ],
+  output: 'export',
   trailingSlash: false,
   images: {
     unoptimized: true,

--- a/apps/nextjs-website/package.json
+++ b/apps/nextjs-website/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next export",
     "lint": "next lint",
     "test": "jest -i"
   },


### PR DESCRIPTION
#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
According to the[ logs, the `export` command](https://github.com/pagopa/developer-portal/actions/runs/5533397666/jobs/10096867359#step:3:320) is deprecated.
Next suggests to generate the `out` folder (previously generated by the `export` command) [updating the `next.config.js` file](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports).

This should also reduce the build time, because we removed a step during the deploy action, because according to their docs:
> After running next build, Next.js will produce an out folder which contains the HTML/CSS/JS assets for your application.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
