### PR TITLE
Refactor menu UI

### DIFF
--- a/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
+++ b/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
@@ -1,6 +1,18 @@
-import { parseMenu } from 'gitbook-docs/parseMenu';
-import { RenderingComponents, renderMenu } from 'gitbook-docs/renderMenu';
-import React, { ReactNode } from 'react';
+/* eslint-disable */
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  List,
+  ListItem,
+  ListItemButton,
+  Typography,
+} from "@mui/material";
+import { parseMenu } from "gitbook-docs/parseMenu";
+import { RenderingComponents, renderMenu } from "gitbook-docs/renderMenu";
+import React, { ReactNode, use, useEffect, useMemo } from "react";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useRouter } from "next/router";
 
 type GuideMenuProps = {
   linkPrefix: string;
@@ -9,12 +21,78 @@ type GuideMenuProps = {
 };
 
 const components: RenderingComponents<ReactNode> = {
-  Link: ({ href, children }) => <a href={href}>{children}</a>,
-  Item: ({ isLeaf, children }) => (
-    <li className={isLeaf ? 'leaf' : 'node'}>{children}</li>
+  Link: ({ href, children }) => {
+    const router = useRouter();
+    const isSelected = useMemo(() => {
+      const lastPathSegment = href?.split("/")[href?.split("/").length - 1];
+      const routerLastPathSegment =
+        router.asPath?.split("/")[router.asPath?.split("/").length - 1];
+
+      return lastPathSegment === routerLastPathSegment;
+    }, [children, href, router.asPath]);
+    return (
+      <ListItemButton
+        component="a"
+        href={href}
+        style={{
+          width: "100%",
+          backgroundColor: isSelected ? "rgba(0, 115, 230, 0.08)" : undefined,
+        }}
+      >
+        <Typography color={isSelected ? "#0062C3" : "black"}>
+          {children}
+        </Typography>
+      </ListItemButton>
+    );
+  },
+  Item: ({ isLeaf, children }) => {
+    const router = useRouter();
+
+    return (
+      <ListItem
+        className={isLeaf ? "leaf" : "node"}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          paddingLeft: "1rem",
+        }}
+      >
+        {isLeaf ? (
+          children
+        ) : (
+          <Accordion
+            style={{
+              background: "transparent",
+              width: "100%",
+              paddingRight: 0,
+            }}
+            defaultExpanded={children[0].props.href.includes(router.asPath)}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              {children[0]}
+            </AccordionSummary>
+            <AccordionDetails>{children.slice(1)}</AccordionDetails>
+          </Accordion>
+        )}
+      </ListItem>
+    );
+  },
+  List: ({ children }) => <List>{children}</List>,
+  Title: ({ children }) => (
+    <Typography
+      component={"h2"}
+      style={{
+        color: "#5C6F82",
+        textTransform: "uppercase",
+        fontWeight: 700,
+        fontSize: 14,
+        marginLeft: "1rem",
+      }}
+    >
+      {children}
+    </Typography>
   ),
-  List: ({ children }) => <ul>{children}</ul>,
-  Title: ({ children }) => <h2>{children}</h2>,
 };
 
 const GuideMenu = ({ menu, assetsPrefix, linkPrefix }: GuideMenuProps) =>

--- a/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
+++ b/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
@@ -37,11 +37,36 @@ const components: RenderingComponents<ReactNode> = {
         style={{
           width: "100%",
           backgroundColor: isSelected ? "rgba(0, 115, 230, 0.08)" : undefined,
+          position: "relative",
         }}
       >
+        {isSelected && (
+          <div
+            style={{
+              position: "absolute",
+              left: -300,
+              width: 300,
+              height: "100%",
+              backgroundColor: "rgba(0, 115, 230, 0.08)",
+            }}
+          />
+        )}
+
         <Typography color={isSelected ? "#0062C3" : "black"}>
           {children}
         </Typography>
+
+        {isSelected && (
+          <div
+            style={{
+              position: "absolute",
+              right: 0,
+              width: 2,
+              height: "100%",
+              backgroundColor: "rgba(0, 98, 195, 1)",
+            }}
+          />
+        )}
       </ListItemButton>
     );
   },
@@ -55,6 +80,7 @@ const components: RenderingComponents<ReactNode> = {
           display: "flex",
           flexDirection: "column",
           alignItems: "flex-start",
+          padding: 0,
           paddingLeft: "1rem",
         }}
       >
@@ -67,12 +93,17 @@ const components: RenderingComponents<ReactNode> = {
               width: "100%",
               paddingRight: 0,
             }}
-            defaultExpanded={children[0].props.href.includes(router.asPath)}
+            defaultExpanded={router.asPath.includes(children[0].props.href)}
           >
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              style={{ height: 60 }}
+            >
               {children[0]}
             </AccordionSummary>
-            <AccordionDetails>{children.slice(1)}</AccordionDetails>
+            <AccordionDetails style={{ padding: 0 }}>
+              {children.slice(1)}
+            </AccordionDetails>
           </Accordion>
         )}
       </ListItem>

--- a/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
+++ b/apps/nextjs-website/src/components/atoms/GuideMenu/GuideMenu.tsx
@@ -21,7 +21,7 @@ type GuideMenuProps = {
 };
 
 const components: RenderingComponents<ReactNode> = {
-  Link: ({ href, children }) => {
+  Link: ({ href, children }: any) => {
     const router = useRouter();
     const isSelected = useMemo(() => {
       const lastPathSegment = href?.split("/")[href?.split("/").length - 1];
@@ -70,7 +70,7 @@ const components: RenderingComponents<ReactNode> = {
       </ListItemButton>
     );
   },
-  Item: ({ isLeaf, children }) => {
+  Item: ({ isLeaf, children }: any) => {
     const router = useRouter();
 
     return (
@@ -109,8 +109,8 @@ const components: RenderingComponents<ReactNode> = {
       </ListItem>
     );
   },
-  List: ({ children }) => <List>{children}</List>,
-  Title: ({ children }) => (
+  List: ({ children }: any) => <List>{children}</List>,
+  Title: ({ children }: any) => (
     <Typography
       component={"h2"}
       style={{

--- a/apps/nextjs-website/src/pages/[productSlug]/guides/[...productGuidePage].tsx
+++ b/apps/nextjs-website/src/pages/[productSlug]/guides/[...productGuidePage].tsx
@@ -9,6 +9,7 @@ import Dropdown from '@/components/atoms/Dropdown/Dropdown';
 import React from 'react';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { translations } from '@/_contents/translations';
+import GuideMenu from '@/components/atoms/GuideMenu/GuideMenu';
 
 type Params = {
   productSlug: string;
@@ -134,12 +135,11 @@ const Page = (props: ProductGuidePageProps) => {
               margin: '32px 0 0 0',
             }}
           >
-            {renderGitBookMarkdown(
-              props.menu,
-              props.pathPrefix,
-              props.assetsPrefix,
-              true
-            )}
+            <GuideMenu
+              menu={props.menu}
+              assetsPrefix={props.assetsPrefix}
+              linkPrefix={props.pathPrefix}
+            />
           </Box>
         </Box>
         <Box sx={{ padding: { xs: '80px 40px', lg: '80px 438px 80px 40px' } }}>


### PR DESCRIPTION
#### List of Changes

- Update guide menu components to look like the mockup
- Accordions are now open depending on the selected menu item
- Selected menu item has a different color, as the mockup.

#### Motivation and Context
Update guide menu UI

#### How Has This Been Tested?
run `npm run dev`  
go to `http://localhost:3000/app-io/guides/io-guida-tecnica/v3.0/setup-iniziale/adesione-tramite-larea-riservata`  

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/developer-portal/assets/18684459/31927d67-f60f-4cfe-be43-5a73d040bf34)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
