### PR TITLE
[DEV-880] - Guides and manual sticky menu

### DIFF
--- a/apps/nextjs-website/src/pages/[productSlug]/guides/[...productGuidePage].tsx
+++ b/apps/nextjs-website/src/pages/[productSlug]/guides/[...productGuidePage].tsx
@@ -108,6 +108,12 @@ const Page = (props: ProductGuidePageProps) => {
               width: { lg: '347px' },
               flexGrow: { lg: 0 },
               flexShrink: { lg: 0 },
+              position: 'sticky',
+              height: '100vh',
+              overflowY: 'auto',
+              top: -74,
+              scrollbarColor: 'red orange',
+              scrollbarWidth: 'thin',
             }}
           >
             <Typography

--- a/apps/nextjs-website/src/styles/globals.css
+++ b/apps/nextjs-website/src/styles/globals.css
@@ -1,5 +1,23 @@
+* {
+  scrollbar-color: initial;
+  scrollbar-width: initial;
+}
+
 body {
   margin: 0;
+  --scrollbar-foreground: #dfe2e5;
+  --scrollbar-background: transparent;
+  scrollbar-color: var(--scrollbar-foreground) var(--scrollbar-background);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-foreground);
+}
+::-webkit-scrollbar-track {
+  background-color: transparent;
 }
 
 .swiper-pagination-bullet {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
This PR sets guides and manual menu position as sticky and adds scrollbar's style

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The menu was disappearing on vertical scroll

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually

#### Screenshots (if appropriate):

The menu is scrollable independently from the page:
![Screenshot from 2023-09-05 11-48-26](https://github.com/pagopa/developer-portal/assets/39835990/52a5a3a7-90db-4f69-b8ca-2d20c2a7abc0)

and it's position is sticky and aligned with in page menu on the right:
![Screenshot from 2023-09-05 11-48-41](https://github.com/pagopa/developer-portal/assets/39835990/b142ef84-29e9-436b-8f6e-b77e1b966f04)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
