### PR TITLE
[DEV-777] Fix "Go to GitHub" link style in ApiSection component

### DIFF
--- a/apps/nextjs-website/src/components/molecules/ApiSection/ApiSection.tsx
+++ b/apps/nextjs-website/src/components/molecules/ApiSection/ApiSection.tsx
@@ -142,6 +142,9 @@ const ApiSection = ({
             <ButtonNaked
               sx={{
                 color: textColor,
+                '&:hover': {
+                  color: textColor,
+                },
               }}
               component={Link}
               aria-label={soapDocumentation.buttonLabel}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Fix "Go to GitHub" link hover style in ApiSection component

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The link was blue on a blue background

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/developer-portal/assets/39835990/013359ae-be42-43bc-95b1-8b281b19326e)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
