### PR TITLE
[DEV-961] Fix the missing mobile image for the guida-tecnica-sugli-avvisi-di-pa…

### DIFF
--- a/apps/nextjs-website/src/_contents/pagoPa/guideLists.ts
+++ b/apps/nextjs-website/src/_contents/pagoPa/guideLists.ts
@@ -72,7 +72,8 @@ export const pagoPaGuideLists: GuideListsData = {
             label: 'Vai alla guida',
           },
           imagePath: '/images/guida-tecnica-sugli-avvisi-di-pagamento.png',
-          mobileImagePath: '/images/avvisi-mobile.png',
+          mobileImagePath:
+            '/images/guida-tecnica-sugli-avvisi-di-pagamento-mobile.png',
         },
         {
           title: 'Linee Guida Brand pagoPA',


### PR DESCRIPTION
#### List of Changes
Fix the path of the "guida tecnica sugli avvisi di pagamento" for mobile rendering

#### Motivation and Context
On mobile devices, the image was missing.

#### How Has This Been Tested?
Manually

#### Screenshots (if appropriate):
<img width="735" alt="Screenshot 2023-09-28 at 14 49 55" src="https://github.com/pagopa/developer-portal/assets/1006711/91b73faa-11b4-45d0-8872-64dbc278dad8">

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
