### PR TITLE
[DEV-740] Add hash router to elements

### DIFF
--- a/apps/nextjs-website/src/components/atoms/ApiViewer/ApiViewer.tsx
+++ b/apps/nextjs-website/src/components/atoms/ApiViewer/ApiViewer.tsx
@@ -23,7 +23,7 @@ const ApiViewer: FC<ApiViewerProps> = ({
       hideTryIt={hideTryIt}
       hideExport
       basePath={`${api?.path}` ?? `${path}/api`}
-      router={typeof window === 'undefined' ? 'memory' : 'history'}
+      router={typeof window === 'undefined' ? 'memory' : 'hash'}
     />
   );
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add hash router configuration to API components from element

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When api pages was reloaded after selecting an endpoint's documentation, next respond with error 404.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
User can navagiate to: http://localhost:3000/send/api and after selecting an endpoint from documentation page will show selected endpoint after reloading page

#### Screenshots (if appropriate):
[Screencast from 03-10-2023 17:27:10.webm](https://github.com/pagopa/developer-portal/assets/24475319/9986d592-cac8-4608-8c7b-b3301335c4b8)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
