### PR TITLE
[DEV-975] - Use shell syntax to read environment variables

### DIFF
--- a/.github/actions/branch-up-to-date/action.yaml
+++ b/.github/actions/branch-up-to-date/action.yaml
@@ -11,7 +11,7 @@ runs:
         TARGET_BRANCH: origin/${{ github.base_ref }}
         HEAD_BRANCH: origin/${{ github.head_ref }}
       run: |
-        if git merge-base --is-ancestor ${{ env.TARGET_BRANCH }} ${{ env.HEAD_BRANCH }}
+        if git merge-base --is-ancestor $TARGET_BRANCH $HEAD_BRANCH
         then
           echo "Your branch is up to date."
           BRANCH_UP_TO_DATE='true'
@@ -29,7 +29,7 @@ runs:
         recreate: true
         message: |
           ## Branch is not up to date with base branch ##
-          @${{ github.actor}} it seems this Pull Request is not updated with base branch.
+          @${{ github.actor }} it seems this Pull Request is not updated with base branch.
           Please proceed with a merge or rebase to solve this.
 
     - name: Failure message

--- a/.github/actions/link-pr-to-jira-activity/action.yaml
+++ b/.github/actions/link-pr-to-jira-activity/action.yaml
@@ -1,12 +1,6 @@
 name: "Lint and Link PR title"
 description: "Validate the PR title and link it to a Jira activity"
 
-inputs:
-  JIRA_COMMENT_REGEX:
-    description: "Pattern to Jira comment"
-    required: false
-    default: "^.*Jira.*"
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/link-pr-to-jira-activity/action.yaml
+++ b/.github/actions/link-pr-to-jira-activity/action.yaml
@@ -19,8 +19,9 @@ runs:
     - name: Extract Jira Issue to Link
       if: steps.lint.outcome == 'success'
       shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
-        PR_TITLE=$(echo "${{ github.event.pull_request.title }}")
         ISSUES_STR=$(awk -F'\\[|\\]' '{print $2}' <<< "$PR_TITLE" | sed "s/#//g" | sed "s/,//g")
         ISSUES=($ISSUES_STR)
         MARKDOWN_CARRIAGE_RETURN="<br>"
@@ -55,13 +56,15 @@ runs:
         recreate: true
         message: |
           ## Jira Pull request Link ##
-          @${{ github.actor}} it seems this Pull Request has no issues that refers to Jira!
+          @${{ github.actor }} it seems this Pull Request has no issues that refers to Jira!
           Please check it out.
           PR's title should be something like: `[B2B-1] Title` where `B2B-1` is the activity's id on Jira.
 
     - name: Failure message
       if: steps.lint.outcome != 'success'
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: |
-        echo "Pull request title (${{ github.event.pull_request.title }}) is not properly formatted or it is not related to any Jira issue"
+        echo "Pull request title ($PR_TITLE) is not properly formatted or it is not related to any Jira issue"
         exit 1


### PR DESCRIPTION
> The best practice to avoid code injection vulnerabilities in GitHub workflows is to set the untrusted input value of the expression to an intermediate environment variable and then use the environment variable using the native syntax of the shell/script interpreter (that is, not ${{ env.VAR }}).

According to GitHub, within `run` or `scripts` in GitHub action, [it is more safe to use the shell syntax to get environment variable](https://github.blog/2023-08-09-four-tips-to-keep-your-github-actions-workflows-secure/#1-dont-use-syntax-in-the-run-section-to-avoid-unexpected-substitution-behavior).

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This should fix the security issue https://github.com/pagopa/developer-portal/security/code-scanning/1

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
