### PR TITLE
[DEV-979] Fixes label 321 as 231 in the footer of site

### DIFF
--- a/apps/nextjs-website/src/_contents/translations.ts
+++ b/apps/nextjs-website/src/_contents/translations.ts
@@ -241,9 +241,9 @@ export const translations = {
             linkType: 'external',
           },
           {
-            ariaLabel: 'Vai al link: Modello 321',
+            ariaLabel: 'Vai al link: Modello 231',
             href: 'https://pagopa.portaleamministrazionetrasparente.it/pagina746_altri-contenuti.html',
-            label: 'Modello 321',
+            label: 'Modello 231',
             linkType: 'external',
           },
         ],


### PR DESCRIPTION
#### List of Changes
Fixed mistyped label in the footer (321 instead of 231)

#### Motivation and Context
The label was wrong

#### How Has This Been Tested?
Manually

#### Screenshots (if appropriate):
<img width="1743" alt="Screenshot 2023-10-05 at 15 20 18" src="https://github.com/pagopa/developer-portal/assets/1006711/25f4ad2e-037f-45c2-9073-c48f722fb670">


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
