### PR TITLE
[DEV-1010] - Update user pool's password policy

### DIFF
--- a/.infrastructure/55_cognito.tf
+++ b/.infrastructure/55_cognito.tf
@@ -23,6 +23,10 @@ resource "aws_cognito_user_pool" "devportal" {
 
   password_policy {
     minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_uppercase                = true
+    require_symbols                  = true
     temporary_password_validity_days = 7
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
According to the [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls), a password is weak if it has less than `8` chars.
It should also allow usage of all characters including unicode and whitespace to be considered as a `strong` password.

#### List of Changes
<!--- Describe your changes in detail -->
- Password must contain lowercase character
- Password must contain uppercase character
- Password must contain at least a number
- Password must contain at least a symbol

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to make sure users' passwords are considered `strong`.

For further details about Cognito user pool's password policy, [check the documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html).

#### How Has This Been Tested?
Manually. The policy has been updated, without the need of deleting the Cognito User Pool.
It does not force users with a _legacy_ password to change it.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
