### PR TITLE
[DEV-1102] - Handle CustomMessage_ResendCode trigger

### DIFF
--- a/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
+++ b/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
@@ -27,10 +27,10 @@ const event: CustomMessageTriggerEvent = {
 };
 
 describe('Handler', () => {
+  const env = {
+    domain: 'thedomain.org',
+  };
   it('should reply with verification link', async () => {
-    const env = {
-      domain: 'thedomain.org',
-    };
     const { response } = await makeHandler(env)(event);
     const { userAttributes, codeParameter } = event.request;
     const expected = emailTemplate(
@@ -40,9 +40,6 @@ describe('Handler', () => {
   });
 
   it('should reply with verification link on resend code request', async () => {
-    const env = {
-      domain: 'thedomain.org',
-    };
     const resendCodeEvent: CustomMessageTriggerEvent = {
       ...event,
       triggerSource: 'CustomMessage_ResendCode',

--- a/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
+++ b/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
@@ -43,11 +43,12 @@ describe('Handler', () => {
     const env = {
       domain: 'thedomain.org',
     };
-    const { response } = await makeHandler(env)({
+    const resendCodeEvent: CustomMessageTriggerEvent = {
       ...event,
       triggerSource: 'CustomMessage_ResendCode',
-    });
-    const { userAttributes, codeParameter } = event.request;
+    };
+    const { response } = await makeHandler(env)(resendCodeEvent);
+    const { userAttributes, codeParameter } = resendCodeEvent.request;
     const expected = emailTemplate(
       `https://${env.domain}/auth/confirmation?username=${userAttributes['sub']}&code=${codeParameter}`
     );

--- a/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
+++ b/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
@@ -38,4 +38,19 @@ describe('Handler', () => {
     );
     expect(response.emailMessage).toStrictEqual(expected);
   });
+
+  it('should reply with verification link on resend email request', async () => {
+    const env = {
+      domain: 'thedomain.org',
+    };
+    const { response } = await makeHandler(env)({
+      ...event,
+      triggerSource: 'CustomMessage_ResendCode',
+    });
+    const { userAttributes, codeParameter } = event.request;
+    const expected = emailTemplate(
+      `https://${env.domain}/auth/confirmation?username=${userAttributes['sub']}&code=${codeParameter}`
+    );
+    expect(response.emailMessage).toStrictEqual(expected);
+  });
 });

--- a/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
+++ b/apps/cognito-functions/src/__tests__/custom-message-handler.test.ts
@@ -39,7 +39,7 @@ describe('Handler', () => {
     expect(response.emailMessage).toStrictEqual(expected);
   });
 
-  it('should reply with verification link on resend email request', async () => {
+  it('should reply with verification link on resend code request', async () => {
     const env = {
       domain: 'thedomain.org',
     };

--- a/apps/cognito-functions/src/custom-message-handler.ts
+++ b/apps/cognito-functions/src/custom-message-handler.ts
@@ -21,7 +21,10 @@ export const makeHandler =
   (env: CustomMessageEnv) => async (event: CustomMessageTriggerEvent) => {
     const username = event.request.userAttributes['sub'];
 
-    if (event.triggerSource === 'CustomMessage_SignUp') {
+    if (
+      event.triggerSource === 'CustomMessage_SignUp' ||
+      event.triggerSource === 'CustomMessage_ResendCode'
+    ) {
       const { codeParameter } = event.request;
       const href = `https://${env.domain}/auth/confirmation?username=${username}&code=${codeParameter}`;
       const emailMessage = emailTemplate(href);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Send verification email to user even when the trigger is `CustomMessage_ResendCode`.

Before this PR, the user receive a default email coming from Cognito.

#### List of Changes
<!--- Describe your changes in detail -->
- Update unit test
- Handle `CustomMessage_ResendCode` trigger

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During sign-up, if a user requests to receive a new verification email, it should receive one.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
