### PR TITLE
[DEV-1123] - Improve PostConfirmationTriggerEvent handling

### DIFF
--- a/apps/cognito-functions/src/main.ts
+++ b/apps/cognito-functions/src/main.ts
@@ -1,9 +1,9 @@
 import { pipe } from 'fp-ts/lib/function';
 import * as E from 'fp-ts/lib/Either';
 import * as PR from 'io-ts/PathReporter';
-import * as customMessage from './custom-message-handler';
 import { SES } from '@aws-sdk/client-ses';
-import * as sendEmail from './post-confirmation-confirm-sign-up-handler';
+import * as customMessage from './custom-message-handler';
+import * as postConfirmation from './post-confirmation-handler';
 import * as defineAuthChallenge from './define-auth-challenge-handler';
 import * as verifyAuthChallenge from './verify-auth-challenge-handler';
 import * as createAuthChallenge from './create-auth-challenge-handler';
@@ -24,7 +24,7 @@ export const postConfirmationHandler = pipe(
     domain: process.env.DOMAIN,
     fromEmailAddress: process.env.FROM_EMAIL_ADDRESS,
   },
-  sendEmail.PostConfirmationConfig.decode,
+  postConfirmation.PostConfirmationConfig.decode,
   E.fold(
     (errors) => {
       // eslint-disable-next-line functional/no-expression-statements
@@ -33,7 +33,7 @@ export const postConfirmationHandler = pipe(
       throw new Error();
     },
     (config) =>
-      sendEmail.makeHandler({
+      postConfirmation.makeHandler({
         ses: new SES(),
         config,
       })


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Send email only when the event is `PostConfirmation_ConfirmSignUp`
- Refactor on file names

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We do not want to get an error on `PostConfirmation_ConfirmForgotPassword` event and we only want to send an email when the `PostConfirmation_ConfirmSignUp` occurs

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
