### PR TITLE
[DEV-1163] table checkboxes on true / false values

### DIFF
--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
@@ -1,12 +1,13 @@
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import MUITableContainer from '@mui/material/TableContainer';
 import MUITable from '@mui/material/Table';
 import MUITableHead from '@mui/material/TableHead';
 import MUITableBody from '@mui/material/TableBody';
 import MUITableRow from '@mui/material/TableRow';
-import MUITableCell from '@mui/material/TableCell';
+import MUITableCell, { TableCellProps } from '@mui/material/TableCell';
 import { ReactNode } from 'react';
 import { TableProps } from 'gitbook-docs/markdoc/schema/table';
+import { Checkbox } from '@mui/material';
 
 export const Table = ({ children }: TableProps<ReactNode>) => (
   <MUITableContainer component={'div'}>
@@ -40,9 +41,31 @@ export const TableH = styled(MUITableCell)(({ theme }) => ({
   padding: '0.5rem 1rem',
 }));
 
-export const TableD = styled(MUITableCell)(({ theme }) => ({
-  border: `1px solid ${theme.palette.divider}`,
-  padding: '0.5rem 1rem',
-}));
+// export const TableD = styled(MUITableCell)(({ theme }) => ({
+//   border: `1px solid ${theme.palette.divider}`,
+//   padding: '0.5rem 1rem',
+// }));
+
+export const TableD = (props: TableCellProps) => {
+  const theme = useTheme();
+  return (
+    <MUITableCell
+      sx={{ border: `1px solid ${theme.palette.divider}` }}
+      {...props}
+    >
+      {props.children == 'true' ? (
+        <Checkbox
+          disabled
+          checked
+          style={{ color: theme.palette.primary.main }}
+        />
+      ) : props.children == 'false' ? (
+        <Checkbox disabled />
+      ) : (
+        props.children || ''
+      )}
+    </MUITableCell>
+  );
+};
 
 export default Table;

--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
@@ -41,10 +41,6 @@ export const TableH = styled(MUITableCell)(({ theme }) => ({
   padding: '0.5rem 1rem',
 }));
 
-// export const TableD = styled(MUITableCell)(({ theme }) => ({
-//   border: `1px solid ${theme.palette.divider}`,
-//   padding: '0.5rem 1rem',
-// }));
 
 export const TableD = (props: TableCellProps) => {
   const theme = useTheme();

--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
@@ -53,7 +53,7 @@ export const TableD = (props: TableCellProps) => {
       sx={{ border: `1px solid ${theme.palette.divider}` }}
       {...props}
     >
-      {props.children == 'true' ? (
+      {props.children === 'true' ? (
         <Checkbox
           disabled
           checked

--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
@@ -41,7 +41,6 @@ export const TableH = styled(MUITableCell)(({ theme }) => ({
   padding: '0.5rem 1rem',
 }));
 
-
 export const TableD = (props: TableCellProps) => {
   const theme = useTheme();
   return (

--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Table.tsx
@@ -55,7 +55,7 @@ export const TableD = (props: TableCellProps) => {
           checked
           style={{ color: theme.palette.primary.main }}
         />
-      ) : props.children == 'false' ? (
+      ) : props.children === 'false' ? (
         <Checkbox disabled />
       ) : (
         props.children || ''


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Now table cells shows a checkbox if their value is `true` or `false`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
DEV-1163

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Go to `/pago-pa/guides/saci/3.1.0/specifiche-attuative-dei-codici-identificativi-di-versamento-riversamento-e-rendicontazione/operazione-di-trasferimento-fondi`, scroll to the table, the rightmost column now has checkboxes instead of true and false 

#### Screenshots (if appropriate):
<img width="767" alt="Screenshot 2023-11-23 at 12 03 25" src="https://github.com/pagopa/developer-portal/assets/18684459/0b0693ce-d4b9-4b15-8e00-8eb6497d8177">


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
