### PR TITLE
[DEV-1275] Set X-Robots-Tag to 'all' in prod's terraform variables

### DIFF
--- a/.infrastructure/env/prod/terraform.tfvars
+++ b/.infrastructure/env/prod/terraform.tfvars
@@ -14,7 +14,7 @@ cdn_custom_headers = [
   {
     header   = "X-Robots-Tag"
     override = true
-    value    = "noindex"
+    value    = "all"
   }
 ]
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Set X-Robots-Tag to 'all' in prod's terraform variables

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The developer Portal's pages are blocked from indexing:
https://www.google.com/search?q=site%3Adeveloper.pagopa.it
Looking at Lighthouse plugin report, it seems to happen because of the X-Robots-Tag rule:
![image](https://github.com/pagopa/developer-portal/assets/39835990/c4c73ccb-1783-4662-99f1-fd03b47313ea)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
