### PR TITLE
[DEV-1235] Preload font

### DIFF
--- a/.changeset/modern-berries-hope.md
+++ b/.changeset/modern-berries-hope.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+[DEV-1235] Preload font

--- a/apps/nextjs-website/src/app/layout.tsx
+++ b/apps/nextjs-website/src/app/layout.tsx
@@ -14,6 +14,7 @@ import AuthProvider from '@/components/organisms/Auth/AuthProvider';
 import CookieBannerScript from '@/components/atoms/CookieBannerScript/CookieBannerScript';
 import BodyWrapper from '@/components/atoms/BodyWrapper/BodyWrapper';
 import Script from 'next/script';
+import { Titillium_Web } from 'next/font/google';
 
 const MATOMO_SCRIPT = `
 var _paq = (window._paq = window._paq || []);
@@ -32,6 +33,14 @@ _paq.push(["enableLinkTracking"]);
   s.parentNode.insertBefore(g, s);
 })();
 `;
+
+const titilliumWeb = Titillium_Web({
+  fallback: ['serif'],
+  subsets: ['latin'],
+  style: 'normal',
+  variable: '--font-titillium-web',
+  weight: ['400', '600', '700'],
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
@@ -61,7 +70,7 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang='it'>
+    <html lang='it' className={titilliumWeb.variable}>
       <head>
         {isProduction && (
           <Script

--- a/apps/nextjs-website/src/styles/globals.css
+++ b/apps/nextjs-website/src/styles/globals.css
@@ -1,6 +1,7 @@
 * {
   scrollbar-color: initial;
   scrollbar-width: initial;
+  font-family: var(--font-titillium-web)!important;
 }
 
 body {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Used `next/font/google` lib to preload **Tittillium** google font
- Set `font-family: var(--font-titillium-web)!important;`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid layout shifts caused by font loading latency

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

[screencast-developer.pagopa.it-2023.12.20-10_20_26.webm](https://github.com/pagopa/developer-portal/assets/16854782/0453c30f-cd54-4fe9-ab35-571e0ceaba41)

I checked if the above problem no longer occurs so I tested several pages to see if they had any layout shifts caused by the text.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
