### PR TITLE
PR size workflow should ignore .infrastructure/.terraform.lock.hcl

### DIFF
--- a/.github/workflows/pr_enrich.yaml
+++ b/.github/workflows/pr_enrich.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: pagopa/github-actions-template/check-pr-size@d91a1fd0b913c9830589be5d86cdb71c90813fae # v1.5.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          ignored_files: 'package-lock.json, docs/'
+          ignored_files: 'package-lock.json, docs/ .infrastructure/.terraform.lock.hcl'
           min_size: 200
           max_size: 800
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Ignore changes on `.infrastructure/.terraform.lock.hcl` when running the PR size workflow

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `.infrastructure/.terraform.lock.hcl` shouldn't be updated manually, and when a provider is updated, this file can change a lot.
We don't want the CI failing due to this kind of changes.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
