### PR TITLE
[DEV-1089] Fix link's title parsing logic

### DIFF
--- a/.changeset/happy-grapes-occur.md
+++ b/.changeset/happy-grapes-occur.md
@@ -1,0 +1,5 @@
+---
+"gitbook-docs": patch
+---
+
+Disable the link's title replacing with destination page title and leave it as it was in Gitbook

--- a/.changeset/happy-grapes-occur.md
+++ b/.changeset/happy-grapes-occur.md
@@ -2,4 +2,4 @@
 "gitbook-docs": patch
 ---
 
-Disable the link's title replacing with destination page title and leave it as it was in Gitbook
+Update the logic that is used to replace the titles of links from GitBook

--- a/packages/gitbook-docs/src/__tests__/parseContent.test.ts
+++ b/packages/gitbook-docs/src/__tests__/parseContent.test.ts
@@ -254,9 +254,7 @@ describe('parseContent', () => {
       parseContent('[Page](http://127.0.0.1:5000/o/xY/s/s1/ "mention")', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { title: 'mention', href: '/to/s1' }, [
-          'Page',
-        ]),
+        new Markdoc.Tag('Link', { title: 'mention', href: '/to/s1' }, ['Page']),
       ]),
     ]);
     expect(

--- a/packages/gitbook-docs/src/__tests__/parseContent.test.ts
+++ b/packages/gitbook-docs/src/__tests__/parseContent.test.ts
@@ -29,14 +29,6 @@ const config = {
       path: '/to/s1',
       title: 'S1 Home',
     },
-    {
-      path: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
-      title: 'Integrazione touch point dell’EC con Checkout',
-    },
-    {
-      path: '/to/s0/comunicare-un-servizio/modificare-o-ampliare-un-servizio',
-      title: 'Modificare o ampliare un servizio',
-    },
   ],
 };
 
@@ -189,7 +181,7 @@ describe('parseContent', () => {
   it('should leave the title of the link as it is', () => {
     expect(
       parseContent(
-        "[redirect](../ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+        "[redirect](../page/1.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
         config
       )
     ).toStrictEqual([
@@ -197,7 +189,7 @@ describe('parseContent', () => {
         new Markdoc.Tag(
           'Link',
           {
-            href: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
+            href: '/to/s0/page/1',
           },
           ['redirect']
         ),
@@ -208,7 +200,7 @@ describe('parseContent', () => {
   it('should replace an ending with `.md` title of the link with the page title', () => {
     expect(
       parseContent(
-        "[integrazione-touch-point-dellec-con-checkout.md](../ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+        "[integrazione-touch-point-dellec-con-checkout.md](../page/1.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
         config
       )
     ).toStrictEqual([
@@ -216,9 +208,9 @@ describe('parseContent', () => {
         new Markdoc.Tag(
           'Link',
           {
-            href: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
+            href: '/to/s0/page/1',
           },
-          ['Integrazione touch point dell’EC con Checkout']
+          ['S0 Page 1']
         ),
         " a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
       ]),

--- a/packages/gitbook-docs/src/__tests__/parseContent.test.ts
+++ b/packages/gitbook-docs/src/__tests__/parseContent.test.ts
@@ -205,6 +205,25 @@ describe('parseContent', () => {
       ]),
     ]);
   });
+  it('should replace an ending with `.md` title of the link with the page title', () => {
+    expect(
+      parseContent(
+        "[integrazione-touch-point-dellec-con-checkout.md](../ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+        config
+      )
+    ).toStrictEqual([
+      new Markdoc.Tag('Paragraph', {}, [
+        new Markdoc.Tag(
+          'Link',
+          {
+            href: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
+          },
+          ['Integrazione touch point dell’EC con Checkout']
+        ),
+        " a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+      ]),
+    ]);
+  });
 
   it('should transform the link but leave its title as it is', () => {
     expect(

--- a/packages/gitbook-docs/src/__tests__/parseContent.test.ts
+++ b/packages/gitbook-docs/src/__tests__/parseContent.test.ts
@@ -29,6 +29,14 @@ const config = {
       path: '/to/s1',
       title: 'S1 Home',
     },
+    {
+      path: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
+      title: 'Integrazione touch point dell’EC con Checkout',
+    },
+    {
+      path: '/to/s0/comunicare-un-servizio/modificare-o-ampliare-un-servizio',
+      title: 'Modificare o ampliare un servizio',
+    },
   ],
 };
 
@@ -159,19 +167,6 @@ describe('parseContent', () => {
     ]);
   });
 
-  it('should replace the title of link', () => {
-    expect(
-      parseContent('Go to [page.md](../home.md "mention")', config)
-    ).toStrictEqual([
-      new Markdoc.Tag('Paragraph', {}, [
-        'Go to ',
-        new Markdoc.Tag('Link', { title: 'mention', href: '/to/s0/home' }, [
-          'S0 Home',
-        ]),
-      ]),
-    ]);
-  });
-
   it('should replace the title of link to an anchor with a human readable text', () => {
     expect(
       parseContent(
@@ -191,28 +186,65 @@ describe('parseContent', () => {
     ]);
   });
 
+  it('should leave the title of the link as it is', () => {
+    expect(
+      parseContent(
+        "[redirect](../ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout.md) a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+        config
+      )
+    ).toStrictEqual([
+      new Markdoc.Tag('Paragraph', {}, [
+        new Markdoc.Tag(
+          'Link',
+          {
+            href: '/to/s0/ente-creditore/modalita-dintegrazione/integrazione-touch-point-dellec-con-checkout',
+          },
+          ['redirect']
+        ),
+        " a Checkout, l'interfaccia di front end di PagoPA S.p.A.",
+      ]),
+    ]);
+  });
+
+  it('should transform the link but leave its title as it is', () => {
+    expect(
+      parseContent(
+        '<a href="comunicare-un-servizio/modificare-o-ampliare-un-servizio.md">modificare-o-ampliare-un-servizio.md</a>',
+        config
+      )
+    ).toStrictEqual([
+      new Markdoc.Tag('Paragraph', {}, [
+        new Markdoc.Tag(
+          'Link',
+          {
+            href: '/to/s0/page/comunicare-un-servizio/modificare-o-ampliare-un-servizio',
+          },
+          ['modificare-o-ampliare-un-servizio.md']
+        ),
+      ]),
+    ]);
+  });
+
   it('should convert href to other gitbook space', () => {
     expect(
       parseContent('[Page](http://localhost:5000/o/KxY/s/s1/)', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { href: '/to/s1' }, ['S1 Home']),
+        new Markdoc.Tag('Link', { href: '/to/s1' }, ['Page']),
       ]),
     ]);
     expect(
       parseContent('[Page](http://localhost:5000/s/s0/page/1)', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { href: '/to/s0/page/1' }, ['S0 Page 1']),
+        new Markdoc.Tag('Link', { href: '/to/s0/page/1' }, ['Page']),
       ]),
     ]);
     expect(
       parseContent('[Page](http://localhost:5000/o/xY/s/s1/ "mention")', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { title: 'mention', href: '/to/s1' }, [
-          'S1 Home',
-        ]),
+        new Markdoc.Tag('Link', { title: 'mention', href: '/to/s1' }, ['Page']),
       ]),
     ]);
   });
@@ -223,7 +255,7 @@ describe('parseContent', () => {
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
         new Markdoc.Tag('Link', { title: 'mention', href: '/to/s1' }, [
-          'S1 Home',
+          'Page',
         ]),
       ]),
     ]);
@@ -231,14 +263,14 @@ describe('parseContent', () => {
       parseContent('[Page](http://127.0.0.1:5000/o/KXY/s/s1/)', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { href: '/to/s1' }, ['S1 Home']),
+        new Markdoc.Tag('Link', { href: '/to/s1' }, ['Page']),
       ]),
     ]);
     expect(
       parseContent('[Page](http://127.0.0.1:5000/s/s0/page/1)', config)
     ).toStrictEqual([
       new Markdoc.Tag('Paragraph', {}, [
-        new Markdoc.Tag('Link', { href: '/to/s0/page/1' }, ['S0 Page 1']),
+        new Markdoc.Tag('Link', { href: '/to/s0/page/1' }, ['Page']),
       ]),
     ]);
   });

--- a/packages/gitbook-docs/src/markdoc/schema/link.ts
+++ b/packages/gitbook-docs/src/markdoc/schema/link.ts
@@ -1,6 +1,5 @@
 import { Schema, Tag } from '@markdoc/markdoc';
 import { LinkAttr } from '../attributes';
-import { PageTitlePath } from '../../parseDoc';
 
 const capitalizeFirstLetter = (text: string): string =>
   text.charAt(0).toUpperCase() + text.slice(1);
@@ -18,10 +17,6 @@ export const link: Schema = {
   },
   transform: (node, config) => {
     const attrs = node.transformAttributes(config);
-    const gitBookPagesWithTitle: ReadonlyArray<PageTitlePath> = config.variables
-      ? [...config.variables.gitBookPagesWithTitle]
-      : [];
-    const page = gitBookPagesWithTitle.find(({ path }) => path === attrs.href);
     const childrenTreeNode = node.transformChildren(config);
 
     const titleFromAnchor =
@@ -33,11 +28,7 @@ export const link: Schema = {
           )
         : undefined;
 
-    const children = page
-      ? [page.title]
-      : titleFromAnchor
-      ? [titleFromAnchor]
-      : childrenTreeNode;
+    const children = titleFromAnchor ? [titleFromAnchor] : childrenTreeNode;
     return new Tag('Link', attrs, children);
   },
 };

--- a/packages/gitbook-docs/src/markdoc/schema/pageLink.ts
+++ b/packages/gitbook-docs/src/markdoc/schema/pageLink.ts
@@ -16,7 +16,6 @@ export const pageLink: Schema = {
     },
   },
   transform: (node, config) => {
-    // TODO: This block of code is very similar to the transform function of the Link. Refactor to reuse other functions.
     // To avoid to render a paragraph as child of PageLink, we Search the `link` types within the children and transform them
     const gitBookPagesWithTitle: ReadonlyArray<PageTitlePath> = config.variables
       ? [...config.variables.gitBookPagesWithTitle]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Disable the link's title replacing with destination page title and leave it as it was in Gitbook

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The team asked to remove the feature

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually and with `npm run compile; npm run test -w gitbook-docs -- --watch`

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
