### PR TITLE
[DEV-1406] Handle the trailing slash of the URL

### DIFF
--- a/.changeset/six-items-exist.md
+++ b/.changeset/six-items-exist.md
@@ -1,0 +1,5 @@
+---
+"cloudfront-functions": patch
+---
+
+[DEV-1406] Fix the trailing slash of the URL

--- a/apps/cloudfront-functions/src/__tests__/viewer-request-handler.test.ts
+++ b/apps/cloudfront-functions/src/__tests__/viewer-request-handler.test.ts
@@ -30,7 +30,7 @@ const makeEvent = (uri: string): AWSCloudFrontFunction.Event => ({
 describe('handler', () => {
   it('should append the html suffix', () => {
     expect(handler(makeEvent('/page')).uri).toBe('/page.html');
-    expect(handler(makeEvent('/page/')).uri).toBe('/page/');
+    expect(handler(makeEvent('/page/')).uri).toBe('/page.html');
     expect(handler(makeEvent('/image.jpg')).uri).toBe('/image.jpg');
     expect(handler(makeEvent('/font.woff2')).uri).toBe('/font.woff2');
     const example0 = '/i-s/g/mo/v1.0/i-p/p-i/v-d';

--- a/apps/cloudfront-functions/src/viewer-request-handler.ts
+++ b/apps/cloudfront-functions/src/viewer-request-handler.ts
@@ -16,14 +16,14 @@ const handler = (
     // Check if the uri refers to a gitbook assets
     const isGitbookAssets = uri.startsWith('/gitbook/docs');
     const isWoff2 = uri.endsWith('.woff2'); // woff2 is a font format
+    const uriEndsWithSlash = uri.endsWith('/');
+
+    if (uriEndsWithSlash) {
+      request.uri = uri.replace(/\/$/, '');
+    }
 
     // Add the .html extension if missing
-    if (
-      !uri.endsWith('/') &&
-      !isGitbookAssets &&
-      !isWoff2 &&
-      !/\.[a-zA-Z]+$/.test(uri)
-    ) {
+    if (!isGitbookAssets && !isWoff2 && !/\.[a-zA-Z]+$/.test(uri)) {
       request.uri += '.html';
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- handle the trailing slash of the URL in cloudfront function
- add tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On any developer portal page (excluding the home page), by adding a forward slash at the end of a path, e.g. https://developer.pagopa.it/app-io/guides/io-guida-tecnica → https://developer.pagopa.it/app-io/guides/io-guida-tecnica/ - causes a 404 error.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
