### PR TITLE
[DEV-1448] Add concurrency in workflows that are using terraform

### DIFF
--- a/.github/workflows/code_review_infra.yaml
+++ b/.github/workflows/code_review_infra.yaml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
 
+    concurrency:
+      group: terraform-${{ matrix.environment }}
+      cancel-in-progress: false
+
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -27,6 +27,7 @@ defaults:
     shell: bash
     working-directory: apps/infrastructure/src
 
+
 permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
@@ -37,6 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     environment: ${{ inputs.environment }}
+
+    concurrency:
+      group: terraform-${{ inputs.environment }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -27,7 +27,6 @@ defaults:
     shell: bash
     working-directory: apps/infrastructure/src
 
-
 permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add concurrency group in workflows

#### List of Changes
<!--- Describe your changes in detail -->
- Add concurrency group
- Do not cancel the in-progress workflows

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When several workflows necessitate the use of Terraform (keeping in mind that both `terraform plan` and `terraform apply` require locking), they run concurrently. 
The first workflow executes immediately, while the subsequent ones wait in line.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
