### PR TITLE
[DEV-1456] Add condition on job check_pr_title

### DIFF
--- a/.github/workflows/check_pr_title.yaml
+++ b/.github/workflows/check_pr_title.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
 
   check_pr_title:
+    # Execute this job only if the head branch is not the one created by changeset
+    if: ${{ github.head_ref }} != 'changeset-release/main'
     name: Check PR title
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Now the job is skipped on PRs created by changeset

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add condition to avoid job execution on particular branch

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We do not want the CI is failing on branches created by changeset

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
