### PR TITLE
[DEV-1545] Add custom PathReporter

### DIFF
--- a/.changeset/polite-buses-agree.md
+++ b/.changeset/polite-buses-agree.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+[DEV-1545] Add custom PathReporter to improve readability of errors raised by decode

--- a/apps/nextjs-website/src/lib/strapi/PathReporter.ts
+++ b/apps/nextjs-website/src/lib/strapi/PathReporter.ts
@@ -1,0 +1,14 @@
+import * as t from 'io-ts';
+
+const getMessage = (error: t.ValidationError): string => {
+  if (error.message) {
+    return error.message;
+  } else {
+    const jsonPath = error.context.map(({ key }) => `${key}`).join('/');
+    const expected = error.context[error.context.length - 1].type.name;
+    return `Invalid value ${error.value} supplied to '${jsonPath}', expected type ${expected}`;
+  }
+};
+
+export const failure = (errors: t.Errors): ReadonlyArray<string> =>
+  errors.map(getMessage);

--- a/apps/nextjs-website/src/lib/strapi/__tests__/fetchFromStrapi.test.ts
+++ b/apps/nextjs-website/src/lib/strapi/__tests__/fetchFromStrapi.test.ts
@@ -109,7 +109,7 @@ describe('fetchFromStrapi', () => {
     });
     const actual = fetchFromStrapi('aPath', 'aPopulate', badCodec)(env);
     const expected = new Error(
-      'Invalid value 1 supplied to : {| data: {| id: string |} |}/data: {| id: string |}/id: string'
+      `Invalid value 1 supplied to '/data/id', expected type string`
     );
     await expect(actual).rejects.toStrictEqual(expected);
   });

--- a/apps/nextjs-website/src/lib/strapi/fetchFromStrapi.ts
+++ b/apps/nextjs-website/src/lib/strapi/fetchFromStrapi.ts
@@ -3,7 +3,7 @@ import { pipe } from 'fp-ts/lib/function';
 import * as R from 'fp-ts/lib/Reader';
 import * as E from 'fp-ts/lib/Either';
 import * as TE from 'fp-ts/lib/TaskEither';
-import * as PR from 'io-ts/lib/PathReporter';
+import * as PR from './PathReporter';
 import { StrapiEnv } from '@/lib/strapi/StapiEnv';
 
 // Function to invoke in order to retrieve data from Strapi.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add a custom `PathReporter`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current message generated by the built-in 'PathReported' when a decoding error occurs is difficult to read. This PR aims to improve message readability. E.s.:
The message before this PR:
```
Invalid value 1 supplied to : {| data: {| id: string |} |}/data: {| id: string |}/id: string
```
The message after this PR:
```
Invalid value 1 supplied to '/data/id', expected type string
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
