### PR TITLE
[DEV-1562] Add cms_google_* parameters to ecs_task_execution

### DIFF
--- a/.changeset/unlucky-crabs-carry.md
+++ b/.changeset/unlucky-crabs-carry.md
@@ -1,0 +1,5 @@
+---
+"infrastructure": patch
+---
+
+[DEV-1562] Add cms_google_* parameters to ecs_task_execution role

--- a/apps/infrastructure/src/iam_policy.tf
+++ b/apps/infrastructure/src/iam_policy.tf
@@ -132,7 +132,10 @@ data "aws_iam_policy_document" "ecs_task_execution" {
       module.secret_cms_jwt_secret.ssm_parameter_arn,
       module.secret_cms_access_key_id.ssm_parameter_arn,
       module.secret_cms_access_key_secret.ssm_parameter_arn,
-      module.secret_cms_github_pat.ssm_parameter_arn
+      module.secret_cms_github_pat.ssm_parameter_arn,
+      module.secret_cms_google_gsuite_hd.ssm_parameter_arn,
+      module.secret_cms_google_oauth_client_id.ssm_parameter_arn,
+      module.secret_cms_google_oauth_client_secret.ssm_parameter_arn,
     ]
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `.ssm_parameter_arn` parameters to `ecs_task_execution` policy 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The role used to execute the strapi application needs permissions to fetch the new secrets

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
N/A


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
