### PR TITLE
[DEV-1405] Preserve scroll position of guide menu

### DIFF
--- a/.changeset/bright-balloons-sparkle.md
+++ b/.changeset/bright-balloons-sparkle.md
@@ -2,4 +2,4 @@
 "nextjs-website": minor
 ---
 
-Preserve scroll position of guide menu
+Scroll the guide menu to the selected item

--- a/.changeset/bright-balloons-sparkle.md
+++ b/.changeset/bright-balloons-sparkle.md
@@ -1,5 +1,5 @@
 ---
-"nextjs-website": patch
+"nextjs-website": minor
 ---
 
 Preserve scroll position of guide menu

--- a/.changeset/bright-balloons-sparkle.md
+++ b/.changeset/bright-balloons-sparkle.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Preserve scroll position of guide menu

--- a/apps/nextjs-website/src/components/atoms/GuideMenu/Menu.tsx
+++ b/apps/nextjs-website/src/components/atoms/GuideMenu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import NextLink from 'next/link';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -87,8 +87,17 @@ const StyledTreeItem = styled(TreeItem)(({ theme }) => ({
 
 const components: RenderingComponents<React.ReactNode> = {
   Item: ({ href, title, children }) => {
+    const ref = React.useRef<HTMLAnchorElement>(null);
+
+    useEffect(() => {
+      if (ref.current && ref.current.href === window.location.href) {
+        ref.current.scrollIntoView({ behavior: 'instant', block: 'center' });
+      }
+    }, []);
+
     const label = (
       <Typography
+        ref={ref}
         variant='sidenav'
         component={NextLink}
         href={href}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Restore scroll position of guide menu after navigation.
Depends on #840 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Guide menu scrolls to the top after click on a menu item

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Open any guide, click on any menu item, and you'll see that the menu's scroll position is preserved

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
