### PR TITLE
[DEV-1321] Increase the distance between the menu and title of guides and manuals

### DIFF
--- a/.changeset/itchy-seas-jam.md
+++ b/.changeset/itchy-seas-jam.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Increase the distance between the menu and title of guides and manuals pages

--- a/apps/nextjs-website/src/app/[productSlug]/guides/[...productGuidePage]/page.tsx
+++ b/apps/nextjs-website/src/app/[productSlug]/guides/[...productGuidePage]/page.tsx
@@ -117,8 +117,8 @@ const Page = async ({ params }: { params: Params }) => {
           />
           <Box
             sx={{
-              margin: '0 auto',
-              padding: '56px 40px',
+              margin: `75px auto`,
+              padding: '88px 0px 24px',
               flexGrow: { lg: 1 },
               maxWidth: {
                 xs: '100%',
@@ -126,7 +126,13 @@ const Page = async ({ params }: { params: Params }) => {
               },
             }}
           >
-            <GitBookContent content={props.body} config={props.bodyConfig} />
+            <Box
+              sx={{
+                padding: '56px 40px',
+              }}
+            >
+              <GitBookContent content={props.body} config={props.bodyConfig} />
+            </Box>
           </Box>
           <Box
             sx={{


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- add paddings

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the title was very close to the menu
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually. Go to any `Guide e Manuali` page.
#### Screenshots (if appropriate):
<img width="1397" alt="image" src="https://github.com/pagopa/developer-portal/assets/16854782/e0a86ecb-9032-4e23-bf40-cef79109cd43">


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
