### PR TITLE
[DEV-1508]: align news showcase on homepage

### DIFF
--- a/.changeset/cold-ads-mate.md
+++ b/.changeset/cold-ads-mate.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Fix news showcase alignment on homepage

--- a/apps/nextjs-website/src/editorialComponents/EContainer/EContainer.tsx
+++ b/apps/nextjs-website/src/editorialComponents/EContainer/EContainer.tsx
@@ -14,6 +14,7 @@ interface Props {
   px?: BoxProps['px'];
   spacing?: GridProps['spacing'];
   sx?: GridProps['sx'];
+  containerSx?: BoxProps['sx'];
 }
 
 const EContainer = (props: Props) => {
@@ -26,13 +27,19 @@ const EContainer = (props: Props) => {
     px,
     spacing,
     sx,
+    containerSx,
   } = props;
   const backgroundIsJSX = isJSX(background);
 
   return (
     <Box
       component='section'
-      sx={{ px: { xs: 4 }, position: 'relative', overflow: 'hidden' }}
+      sx={{
+        px: { xs: 4 },
+        position: 'relative',
+        overflow: 'hidden',
+        ...containerSx,
+      }}
       py={py}
       px={px}
       bgcolor={!backgroundIsJSX ? background : undefined}

--- a/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
+++ b/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
@@ -3,6 +3,7 @@ import LinkButton from '@/components/atoms/LinkButton/LinkButton';
 import { Typography, Grid, Stack, Box, useTheme } from '@mui/material';
 import Image from 'next/image';
 import { useMemo } from 'react';
+import EContainer from '../EContainer/EContainer';
 
 interface INewsroomItem {
   comingSoonLabel?: string;
@@ -133,7 +134,7 @@ const Newsroom = (props: INewsroom) => {
   );
 
   return (
-    <Box ml={{ sm: 4, md: 3, xl: 6 }}>
+    <EContainer>
       <Grid
         container
         spacing={{ xs: 2, md: 3 }}
@@ -142,9 +143,8 @@ const Newsroom = (props: INewsroom) => {
           flexWrap: { xs: 'nowrap', md: 'wrap' },
           maxWidth: { md: '1280px', lg: '1310px' },
           mx: 'auto',
-          marginLeft: { sm: '-32px', md: '-16px', lg: 'auto' },
-          'div.MuiGrid-item:first-of-type': {
-            marginLeft: { xs: '32px', sm: '16px', md: '0px' },
+          '&.MuiGrid-container': {
+            marginLeft: { md: '-24px' },
           },
           overflowX: 'scroll',
           paddingRight: '32px',
@@ -156,7 +156,7 @@ const Newsroom = (props: INewsroom) => {
       >
         {news}
       </Grid>
-    </Box>
+    </EContainer>
   );
 };
 

--- a/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
+++ b/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
@@ -134,7 +134,7 @@ const Newsroom = (props: INewsroom) => {
   );
 
   return (
-    <EContainer>
+    <EContainer containerSx={{ px: { xs: 0 } }}>
       <Grid
         container
         spacing={{ xs: 2, md: 3 }}
@@ -142,15 +142,12 @@ const Newsroom = (props: INewsroom) => {
         sx={{
           flexWrap: { xs: 'nowrap', md: 'wrap' },
           maxWidth: { md: '1280px', lg: '1310px' },
-          mx: 'auto',
           '&.MuiGrid-container': {
             marginLeft: { md: '-24px' },
           },
           overflowX: 'scroll',
-          paddingRight: '32px',
           width: {
             xs: 'auto',
-            md: '100%',
           },
         }}
       >

--- a/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
+++ b/apps/nextjs-website/src/editorialComponents/Newsroom/Newsroom.tsx
@@ -143,6 +143,7 @@ const Newsroom = (props: INewsroom) => {
           flexWrap: { xs: 'nowrap', md: 'wrap' },
           maxWidth: { md: '1280px', lg: '1310px' },
           '&.MuiGrid-container': {
+            padding: { xs: '0 32px', lg: 0 },
             marginLeft: { md: '-24px' },
           },
           overflowX: 'scroll',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Align news showcase on homepage

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The news showcase was misaligned with the rest of the homepage

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually

#### Screenshots (if appropriate):
![Screenshot 2024-05-07 alle 15 15 02](https://github.com/pagopa/developer-portal/assets/146933303/2bfb9b45-a7bb-48c3-8f85-8a2aa0d04eb6)
![Screenshot 2024-05-07 alle 15 15 58](https://github.com/pagopa/developer-portal/assets/146933303/bd37cb39-6973-4988-999f-17ac6a555763)
![Screenshot 2024-05-07 alle 15 16 11](https://github.com/pagopa/developer-portal/assets/146933303/f34c12e5-ae31-4f35-8a6e-7db55ed529b5)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
