### PR TITLE
[EC-310] -  host authenticated user now can subscribe to webinar

### DIFF
--- a/.changeset/stale-goats-attack.md
+++ b/.changeset/stale-goats-attack.md
@@ -1,0 +1,5 @@
+---
+"infrastructure": minor
+---
+
+Fix hosts iam role to allow subscription to webinars (dynamodb permissions)

--- a/apps/infrastructure/src/modules/website/iam_role.tf
+++ b/apps/infrastructure/src/modules/website/iam_role.tf
@@ -73,6 +73,17 @@ resource "aws_iam_role_policy" "devportal_authenticated_host_user" {
         Resource = [
           "${module.dynamodb_webinar_questions.dynamodb_table_arn}",
         ]
+      },
+      {
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:Query",
+          "dynamodb:DeleteItem"
+        ],
+        Effect = "Allow",
+        Resource = [
+          "${module.dynamodb_webinar_subscriptions.dynamodb_table_arn}",
+        ]
       }
     ]
   })


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Added permissions to write, delete and query the subscription dynamodb to host authenticated users role

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Host authenticated users role didn't have permissions on the webinar subscriptions dynamodb, hence they could not subscribe to webinars.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
