### PR TITLE
Fix compile error of strapi-provider-upload-custom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54127,6 +54127,7 @@
       "devDependencies": {
         "eslint": "^8.40.0",
         "eslint-config-custom": "*",
+        "shx": "^0.3.4",
         "typescript": "^5.0.2"
       },
       "engines": {

--- a/packages/strapi-provider-upload-custom/package.json
+++ b/packages/strapi-provider-upload-custom/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "eslint": "^8.40.0",
     "eslint-config-custom": "*",
+    "shx": "^0.3.4",
     "typescript": "^5.0.2"
   },
   "engines": {

--- a/packages/strapi-provider-upload-custom/tsconfig.json
+++ b/packages/strapi-provider-upload-custom/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@strapi/typescript-utils/tsconfigs/server", "../../tsconfig.json"],
+  "extends": ["../../tsconfig.json"],
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `shx` dependency to strapi-provider-upload-custom
- Update `tsconfig.json` of strapi-provider-upload-custom
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Strapi-provider-upload-custom `dist` folder is not generated if you run `npm run compile`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually. Run `npm run compile`
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
