### PR TITLE
[DEV-1705] Add --only-show-errors to s3 sync command

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -96,7 +96,7 @@ runs:
 
     - name: Deploy to S3 Bucket
       shell: bash
-      run: aws s3 sync ./apps/nextjs-website/out s3://${{ inputs.bucket }} --delete
+      run: aws s3 sync ./apps/nextjs-website/out s3://${{ inputs.bucket }} --delete --only-show-errors
 
     - name: Create AWS Cloudfront Invalidation
       shell: bash


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add --only-show-errors to s3 sync command in deploy action

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
S3 sync command prints every copy operation it performs. This can lead to non-optimal performance with an high number of objects. For this reason, the --only-show-errors parameter will only show unsuccessful copies reducing the overall time.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
