### PR TITLE
fix: not launching Check PR Title action on changeset PRs

### DIFF
--- a/.github/workflows/check_pr_title.yaml
+++ b/.github/workflows/check_pr_title.yaml
@@ -2,6 +2,12 @@ name: Check PR title
 
 on:
   pull_request:
+    # Ignore Changeset PRs
+    paths-ignore:
+      - '**/package.json'
+      - '**/CHANGELOG.md'
+      - '.changeset/**'
+      - 'package-lock.json'
     types:
       - opened
       - edited


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Adding path filters on `Check PR title` workflow

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `Check PR title` workflow should not run for Changeset PRs. The workflow failing causes the CODEOWNERS to not be able to merge the PR although approved.

![image](https://github.com/user-attachments/assets/37dfdeec-98a9-4c8d-9a61-4285bce20fa5)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
