### PR TITLE
[DEV-1925] Fix links out of bound in guides

### DIFF
--- a/.changeset/modern-chicken-check.md
+++ b/.changeset/modern-chicken-check.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Add wordwrap break word to links

--- a/apps/nextjs-website/src/components/organisms/GitBookContent/components/Link.tsx
+++ b/apps/nextjs-website/src/components/organisms/GitBookContent/components/Link.tsx
@@ -5,7 +5,11 @@ import { useTheme } from '@mui/material';
 export const Link = ({ title, href, children }: LinkProps<ReactNode>) => {
   const { palette } = useTheme();
   return (
-    <a href={href} title={title} style={{ color: palette.primary.main }}>
+    <a
+      href={href}
+      title={title}
+      style={{ wordWrap: 'break-word', color: palette.primary.main }}
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add break-word to links coming from gitbook
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Links coming from gitbook went out of bound on mobile
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
[Localhost ](http://localhost:3000/pago-pa/guides/stampa-avvisi-pagamento)
#### Screenshots (if appropriate):
<img width="213" alt="image" src="https://github.com/user-attachments/assets/e1fa6769-015f-4240-ae78-117a9474dae1">

<img width="217" alt="image" src="https://github.com/user-attachments/assets/e4f9a952-4851-4c19-8cd4-63bdc37b9381">

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
