### PR TITLE
[CAI-249] No masked reference links

### DIFF
--- a/apps/chatbot/src/modules/chatbot.py
+++ b/apps/chatbot/src/modules/chatbot.py
@@ -127,7 +127,11 @@ class Chatbot():
     def mask_pii(self, message: str) -> str:
         if USE_PRESIDIO:
             try:
-                return self.pii.mask_pii(message)
+                split_message = message.split("Rif:")
+                masked_message = self.pii.mask_pii(split_message[0])
+                if len(split_message)>1:
+                    masked_message = masked_message + "Rif:" + split_message[1]
+                return masked_message
             except Exception as e:
                 logging.warning(f"[chatbot.py - mask_pii] exception in mask_pii: {e}")
         else:


### PR DESCRIPTION
#### List of Changes
<!--- Describe your changes in detail -->
in `chatbot.py` the method `mask_pii()` masks only the response content and not the reference links with presidio

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
no masked reference links

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
locally

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
