### PR TITLE
[DEV-2282] Fix webinar slug validation to prevent editors from emptying the field

### DIFF
--- a/.changeset/cuddly-spiders-sleep.md
+++ b/.changeset/cuddly-spiders-sleep.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Fix webinar slug validation

--- a/apps/strapi-cms/src/api/webinar/content-types/webinar/lifecycles.ts
+++ b/apps/strapi-cms/src/api/webinar/content-types/webinar/lifecycles.ts
@@ -99,7 +99,7 @@ const validateSlugBeforeUpdate = async (
   const slug = event.params.data.slug || previousWebinar?.slug;
   validateSlug(slug);
 
-  if (previousWebinar && event.params.data.slug && previousWebinar.slug !== event.params.data.slug) {
+  if ((event.params.data.slug || event.params.data.slug === null) && (previousWebinar && previousWebinar.slug !== event.params.data.slug)) {
     throw new errors.ApplicationError(
       'The slug of a webinar cannot be changed'
     );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Fix webinar slug validation to prevent editors from emptying the field

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
