### PR TITLE
[CAI-415] - Bug Fix of Presidio in Langfuse

### DIFF
--- a/.changeset/tidy-geckos-protect.md
+++ b/.changeset/tidy-geckos-protect.md
@@ -1,0 +1,5 @@
+---
+"chatbot": patch
+---
+
+Fix double run of presidio in langfuse

--- a/.changeset/tidy-geckos-protect.md
+++ b/.changeset/tidy-geckos-protect.md
@@ -2,4 +2,4 @@
 "chatbot": patch
 ---
 
-Fix double run of presidio in langfuse
+Fix double run of Presidio in Langfuse

--- a/apps/chatbot/src/modules/chatbot.py
+++ b/apps/chatbot/src/modules/chatbot.py
@@ -329,10 +329,7 @@ class Chatbot:
 
             if flag:
                 trace.score(
-                    name=name,
-                    value=value,
-                    data_type=data_type,
-                    comment=comment
+                    name=name, value=value, data_type=data_type, comment=comment
                 )
                 logger.warning(
                     f"Add score {name}: {value} in trace {trace_id}.\n"
@@ -434,7 +431,7 @@ class Chatbot:
                 response_json["contexts"] = retrieved_contexts
 
             trace.update(
-                output=self.mask_pii(response_json["response"]),
+                output=response_json["response"],
                 metadata={"contexts": retrieved_contexts},
                 tags=response_json["topics"],
             )


### PR DESCRIPTION
#### List of Changes
Fix the bug where Presidio mask PII in Langfuse. It was running twice for the output.

#### Motivation and Context
have consintency between what is written in the DeveloperPortal chathistory and Langfuse.

#### How Has This Been Tested?
Locally

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
