### PR TITLE
[CAI-508] Add content wrapper to Privacy Policy and Terms of Service pages

### DIFF
--- a/.changeset/solid-dolls-trade.md
+++ b/.changeset/solid-dolls-trade.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Add ContentWrapper to PrivacyPolicy and TermsOfService

--- a/apps/nextjs-website/src/app/privacy-policy/page.tsx
+++ b/apps/nextjs-website/src/app/privacy-policy/page.tsx
@@ -2,6 +2,7 @@ import PrivacyPolicyTemplate from '@/components/templates/PrivacyPolicyTemplate/
 import { baseUrl } from '@/config';
 import { makeMetadata } from '@/helpers/metadata.helpers';
 import { Metadata } from 'next';
+import ContentWrapper from '@/components/atoms/ContentWrapper/ContentWrapper';
 
 export async function generateMetadata(): Promise<Metadata> {
   return makeMetadata({
@@ -12,7 +13,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 const PrivacyPolicy = () => {
-  return <PrivacyPolicyTemplate />;
+  return (
+    <ContentWrapper>
+      <PrivacyPolicyTemplate />
+    </ContentWrapper>
+  );
 };
 
 export default PrivacyPolicy;

--- a/apps/nextjs-website/src/app/terms-of-service/page.tsx
+++ b/apps/nextjs-website/src/app/terms-of-service/page.tsx
@@ -2,6 +2,7 @@ import TermsOfServiceTemplate from '@/components/templates/TermsOfServiceTemplat
 import { baseUrl } from '@/config';
 import { makeMetadata } from '@/helpers/metadata.helpers';
 import { Metadata } from 'next';
+import ContentWrapper from '@/components/atoms/ContentWrapper/ContentWrapper';
 
 export async function generateMetadata(): Promise<Metadata> {
   return makeMetadata({
@@ -12,7 +13,11 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 const TermsOfService = () => {
-  return <TermsOfServiceTemplate />;
+  return (
+    <ContentWrapper>
+      <TermsOfServiceTemplate />
+    </ContentWrapper>
+  );
 };
 
 export default TermsOfService;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add content wrapper to Privacy Policy and Terms of Service pages
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The content wrapper adds a div with the "chatbot-page-content" id, needed for indicization
#### How Has This Been Tested?
Localhost
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="1175" height="409" alt="image" src="https://github.com/user-attachments/assets/f245b4a5-fc92-423b-806f-08ae3047c5ff" />
<img width="1077" height="277" alt="image" src="https://github.com/user-attachments/assets/bc47b7b0-1fe5-446e-930e-dd7f36a915cc" />

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
