### PR TITLE
[DEV-2605]  Fixed SyntaxHighlighter "split is not a function" error by improving data handling in code blocks

### DIFF
--- a/.changeset/free-chefs-stay.md
+++ b/.changeset/free-chefs-stay.md
@@ -2,4 +2,4 @@
 "nextjs-website": patch
 ---
 
-Fixed SyntaxHighlighter "split is not a function" error by improving data handling in code blocks
+Fix SyntaxHighlighter "split is not a function" error by improving data handling in code blocks

--- a/.changeset/free-chefs-stay.md
+++ b/.changeset/free-chefs-stay.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Fixed SyntaxHighlighter "split is not a function" error by improving data handling in code blocks

--- a/apps/nextjs-website/src/components/molecules/BlocksRendererClient/BlocksRendererClient.tsx
+++ b/apps/nextjs-website/src/components/molecules/BlocksRendererClient/BlocksRendererClient.tsx
@@ -89,16 +89,36 @@ const BlocksRendererClient = ({
         list: ({ children }) => {
           return <ul style={listStyle}>{children}</ul>;
         },
-      }}
-      modifiers={{
         code: ({ children }) => {
+          // Extract code string safely from children
+          // eslint-disable-next-line functional/no-let
+          let codeString = '';
+
+          if (typeof children === 'string') {
+            codeString = children;
+          } else if (
+            children &&
+            typeof children === 'object' &&
+            'props' in children
+          ) {
+            const reactElement = children as ReactElement;
+            if (typeof reactElement.props?.children === 'string') {
+              codeString = reactElement.props.children;
+            } else if (Array.isArray(reactElement.props?.children)) {
+              // Handle array of children, join them as text
+              codeString = reactElement.props.children
+                .filter((child: any) => typeof child === 'string')
+                .join('');
+            }
+          }
+
           return (
-            <CodeBlockPart
-              code={(children as ReactElement).props.children}
-              showLineNumbers={false}
-            />
+            <CodeBlockPart code={codeString || ''} showLineNumbers={false} />
           );
         },
+      }}
+      modifiers={{
+        code: ({ children }) => <code>{children}</code>,
       }}
     />
   );

--- a/apps/nextjs-website/src/components/molecules/CodeBlockPart/CodeBlockPart.tsx
+++ b/apps/nextjs-website/src/components/molecules/CodeBlockPart/CodeBlockPart.tsx
@@ -27,6 +27,8 @@ const CodeBlockPart = ({
   maxWidth = 'auto',
   wrapLines = true,
 }: CodeBlockPartProps) => {
+  // Ensure code is always a string to prevent split errors
+  const safeCode = typeof code === 'string' ? code : String(code || '');
   const { spacing, palette } = useTheme();
   const t = useTranslations('shared');
   const isLightMode = mode === 'light';
@@ -66,7 +68,7 @@ const CodeBlockPart = ({
           width: isLightMode ? '' : '100%',
         }}
       >
-        {code}
+        {safeCode}
       </SyntaxHighlighter>
       {title && (
         <Typography
@@ -93,7 +95,7 @@ const CodeBlockPart = ({
       >
         <Box marginY={'4px'} marginRight={{ xs: '5px', md: '10px' }}>
           <CopyToClipboard
-            textToCopy={code}
+            textToCopy={safeCode}
             copiedTooltipLabel={t('copiedTooltip')}
             copyColor={copyColor}
           />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
BlocksRendererClient.tsx:
    - Moved code block handling from modifiers to blocks to prevent HTML hydration errors (`<pre> inside <p>`)
    - Added robust type checking and data extraction for code content
    - Handle string, ReactElement, and array cases safely
    - Added fallback to empty string if extraction fails
    - Added simple inline `<code>` element in modifiers for text formatting

CodeBlockPart.tsx:
    - Added defensive coding with safeCode variable to ensure string type
    - Applied safeCode to both SyntaxHighlighter component and CopyToClipboard
    - Prevents runtime errors when non-string values are passed

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
