### PR TITLE
[DEV-4043] Add Heartbeat feature flag

### DIFF
--- a/.changeset/flat-points-leave.md
+++ b/.changeset/flat-points-leave.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Add Heartbeat feature flag

--- a/apps/nextjs-website/src/config.ts
+++ b/apps/nextjs-website/src/config.ts
@@ -50,6 +50,8 @@ export const chatMaxHistoryMessages =
   parseInt(`${process.env.NEXT_PUBLIC_CHAT_MAX_HISTORY_MESSAGES}`) || 10;
 // Array that defines the header level for which to show component in the in-page menu
 export const headingLevelsToShowInMenu = [2, 3];
+export const webinarHeartbeatEnabled =
+  process.env.NEXT_PUBLIC_WEBINAR_HEARTBEAT_ENABLED === 'true';
 export const webinarHeartbeatUrl =
   process.env.NEXT_PUBLIC_WEBINAR_HEARTBEAT_URL;
 export const webinarHeartbeatIntervalInSeconds =

--- a/apps/nextjs-website/src/config.ts
+++ b/apps/nextjs-website/src/config.ts
@@ -50,7 +50,7 @@ export const chatMaxHistoryMessages =
   parseInt(`${process.env.NEXT_PUBLIC_CHAT_MAX_HISTORY_MESSAGES}`) || 10;
 // Array that defines the header level for which to show component in the in-page menu
 export const headingLevelsToShowInMenu = [2, 3];
-export const webinarHeartbeatEnabled =
+export const isWebinarHeartbeatEnabled =
   process.env.NEXT_PUBLIC_WEBINAR_HEARTBEAT_ENABLED === 'true';
 export const webinarHeartbeatUrl =
   process.env.NEXT_PUBLIC_WEBINAR_HEARTBEAT_URL;

--- a/apps/nextjs-website/src/helpers/webinar.helpers.tsx
+++ b/apps/nextjs-website/src/helpers/webinar.helpers.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Webinar } from '@/lib/webinars/types';
 import {
-  webinarHeartbeatEnabled,
+  isWebinarHeartbeatEnabled,
   webinarHeartbeatIntervalInSeconds,
 } from '@/config';
 import { sendWebinarHeartbeat } from '@/lib/webinarApi';
@@ -173,7 +173,7 @@ export const useWebinar = () => {
   ]);
 
   useEffect(() => {
-    if (!webinarHeartbeatEnabled || !webinar || !isVideoPlaying) return;
+    if (!isWebinarHeartbeatEnabled || !webinar || !isVideoPlaying) return;
 
     // Send heartbeat immediately
     const sendHeartbeat = async () => {

--- a/apps/nextjs-website/src/helpers/webinar.helpers.tsx
+++ b/apps/nextjs-website/src/helpers/webinar.helpers.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Webinar } from '@/lib/webinars/types';
-import { webinarHeartbeatIntervalInSeconds } from '@/config';
+import {
+  webinarHeartbeatEnabled,
+  webinarHeartbeatIntervalInSeconds,
+} from '@/config';
 import { sendWebinarHeartbeat } from '@/lib/webinarApi';
 
 const COMING_SOON_START_TIME_DELTA_MS = 39 * 30 * 60 * 1000; // 19.5 hours
@@ -170,7 +173,7 @@ export const useWebinar = () => {
   ]);
 
   useEffect(() => {
-    if (!webinar || !isVideoPlaying) return;
+    if (!webinarHeartbeatEnabled || !webinar || !isVideoPlaying) return;
 
     // Send heartbeat immediately
     const sendHeartbeat = async () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add Heartbeat feature flag

This pull request introduces a new feature flag for the Heartbeat functionality in the Next.js website, allowing the Heartbeat to be toggled on or off via environment configuration. The main changes are focused on making the Heartbeat feature conditional and configurable.

**Feature flag introduction and integration:**

* Added a new `webinarHeartbeatEnabled` export in `config.ts`, which is set based on the `NEXT_PUBLIC_WEBINAR_HEARTBEAT_ENABLED` environment variable. This allows enabling or disabling the Heartbeat feature without code changes.
* Updated `webinar.helpers.tsx` to import and use the new `webinarHeartbeatEnabled` flag, so the Heartbeat logic only runs if the feature is enabled.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
