### PR TITLE
[DEV-4033] fix soap api sync

### DIFF
--- a/.changeset/common-dodos-leave.md
+++ b/.changeset/common-dodos-leave.md
@@ -1,0 +1,5 @@
+---
+"soap-api-data": patch
+---
+
+Fix populate for strapi 5 update

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -25,7 +25,7 @@ async function main() {
   // eslint-disable-next-line functional/no-try-statements
   try {
     const { data } = await fetchFromStrapi<StrapiSoapApiDetails>(
-      `api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][populate][0]=slug&populate[apiSoapDetail][populate][1]=repositoryUrl&populate[apiSoapDetail][populate][2]=dirName&filters[apiSoapDetail][$null]=false`
+      `/api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
     );
     strapiSoapApiDetails = data;
   } catch (error) {

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -5,13 +5,11 @@ import { resolve } from 'path';
 
 interface StrapiSoapApiDetails {
   readonly id: number;
-  readonly attributes: {
-    readonly apiSoapDetail: {
-      readonly repositoryUrl: string;
-      readonly branch: string;
-      readonly repositoryPath: string;
-      readonly dirName: string;
-    };
+  readonly apiSoapDetail: {
+    readonly repositoryUrl: string;
+    readonly branch: string;
+    readonly repositoryPath: string;
+    readonly dirName: string;
   };
 }
 
@@ -49,7 +47,7 @@ async function main() {
   }
 
   const soapApiDetails = strapiSoapApiDetails.map(
-    (entry) => entry.attributes.apiSoapDetail
+    (entry) => entry.apiSoapDetail
   );
   await mkdir(outputDir, { recursive: true });
   await writeFile(outputPath, JSON.stringify(soapApiDetails, null, 2));

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -49,6 +49,7 @@ async function main() {
   const soapApiDetails = strapiSoapApiDetails.map(
     (entry) => entry.apiSoapDetail
   );
+  console.log('JSON CONTENT: \n', JSON.stringify(soapApiDetails, null, 2));
   await mkdir(outputDir, { recursive: true });
   await writeFile(outputPath, JSON.stringify(soapApiDetails, null, 2));
 

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -30,7 +30,7 @@ async function main() {
   // eslint-disable-next-line functional/no-try-statements
   try {
     const { data } = await fetchFromStrapi<StrapiSoapApiDetails>(
-      `/api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
+      `api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
     );
     strapiSoapApiDetails = data;
   } catch (error) {

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -20,15 +20,10 @@ async function main() {
 
   // eslint-disable-next-line functional/no-let
   let strapiSoapApiDetails;
-
-  console.log(
-    'Fetching from : ',
-    `/api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
-  );
   // eslint-disable-next-line functional/no-try-statements
   try {
     const { data } = await fetchFromStrapi<StrapiSoapApiDetails>(
-      `api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
+      `api/apis-data/?[locale]=${locale}&populate[apiSoapDetail]=*&filters[apiSoapDetail][$null]=false`
     );
     strapiSoapApiDetails = data;
   } catch (error) {

--- a/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
+++ b/packages/soap-api-data/src/scripts/generateSoapApiRepositoriesList.ts
@@ -22,6 +22,11 @@ async function main() {
 
   // eslint-disable-next-line functional/no-let
   let strapiSoapApiDetails;
+
+  console.log(
+    'Fetching from : ',
+    `/api/apis-data/?[locale]=${locale}&populate[apiSoapDetail][fields][0]=slug&populate[apiSoapDetail][fields][1]=repositoryUrl&populate[apiSoapDetail][fields][2]=dirName&filters[apiSoapDetail][$null]=false`
+  );
   // eslint-disable-next-line functional/no-try-statements
   try {
     const { data } = await fetchFromStrapi<StrapiSoapApiDetails>(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
This pull request addresses compatibility issues with Strapi 5 by updating how related fields are populated in the SOAP API data fetching script. The main change ensures the correct usage of the Strapi 5 API for field population, which resolves issues with the data retrieval process.

**Strapi 5 compatibility updates:**

* Updated the `fetchFromStrapi` call in `generateSoapApiRepositoriesList.ts` to use the `[fields]` syntax for populating `apiSoapDetail` fields (`slug`, `repositoryUrl`, and `dirName`), replacing the deprecated `[populate]` syntax.
* Added a changeset file `.changeset/common-dodos-leave.md` describing the patch and its purpose to fix population for Strapi 5.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

