### PR TITLE
[DEV-4435] Add guard checking missing README.md or SUMMARY.md in sync action

### DIFF
--- a/.github/actions/sync-gitbook-docs/action.yaml
+++ b/.github/actions/sync-gitbook-docs/action.yaml
@@ -182,7 +182,9 @@ runs:
           if [[ -n "$LOCALE" ]]; then
             S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${LOCALE}/${S3_DIRNAMES_JSON_PATH}"
           else
-            S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${S3_DIRNAMES_JSON_PATH}"
+            echo "LOCALE is not set. Skipping documentation directories validation."
+            echo "::endgroup::"
+            exit 0
           fi
           aws s3 cp "$S3_DIRNAMES" bucket-dirNames.json || echo '{"dirNames": []}' > bucket-dirNames.json
           CANDIDATES=$(jq -r '.dirNames[]' bucket-dirNames.json 2>/dev/null)

--- a/.github/actions/sync-gitbook-docs/action.yaml
+++ b/.github/actions/sync-gitbook-docs/action.yaml
@@ -165,27 +165,27 @@ runs:
       run: |
         echo "::group::Validate documentation directories"
         # Guard: fail before any S3 change if a doc directory matching a dirName
-        # (from the filter list or from the bucket dirNames.json) is missing at
-        # least one of README.md or SUMMARY.md.
+        # is missing at least one of README.md or SUMMARY.md.
+        # Candidate dirNames come from the filter list when provided, otherwise
+        # from the bucket dirNames.json.
 
-        # Fetch the published dirNames list from the bucket.
-        if [[ -n "$LOCALE" ]]; then
-          S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${LOCALE}/${S3_DIRNAMES_JSON_PATH}"
-        else
-          S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${S3_DIRNAMES_JSON_PATH}"
-        fi
-        aws s3 cp "$S3_DIRNAMES" bucket-dirNames.json || echo '{"dirNames": []}' > bucket-dirNames.json
-
-        # Collect candidate directories from the bucket dirNames.json...
-        CANDIDATES=$(jq -r '.dirNames[]' bucket-dirNames.json 2>/dev/null | sort -u)
-
-        # ...and from the filter list, when provided.
         if [[ -n "$DIR_NAMES_FILTER" ]]; then
+          # Use the filter list as the candidate directories.
+          CANDIDATES=""
           IFS=',' read -ra FILTER_DIRS <<< "$DIR_NAMES_FILTER"
           for d in "${FILTER_DIRS[@]}"; do
             d=$(echo "$d" | xargs)
             [[ -n "$d" ]] && CANDIDATES=$(printf '%s\n%s\n' "$CANDIDATES" "$d")
           done
+        else
+          # Fetch the published dirNames list from the bucket.
+          if [[ -n "$LOCALE" ]]; then
+            S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${LOCALE}/${S3_DIRNAMES_JSON_PATH}"
+          else
+            S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${S3_DIRNAMES_JSON_PATH}"
+          fi
+          aws s3 cp "$S3_DIRNAMES" bucket-dirNames.json || echo '{"dirNames": []}' > bucket-dirNames.json
+          CANDIDATES=$(jq -r '.dirNames[]' bucket-dirNames.json 2>/dev/null)
         fi
         CANDIDATES=$(echo "$CANDIDATES" | sort -u)
 

--- a/.github/actions/sync-gitbook-docs/action.yaml
+++ b/.github/actions/sync-gitbook-docs/action.yaml
@@ -154,6 +154,64 @@ runs:
         aws_region: eu-south-1
         role_to_assume: ${{ inputs.deploy_iam_role }}
 
+    - name: Validate documentation directories
+      shell: bash
+      working-directory: ./devportal-docs
+      env:
+        ENV_SHORT: ${{ env.ENV_SHORT }}
+        S3_DIRNAMES_JSON_PATH: ${{ inputs.s3_dirnames_json_path }}
+        DIR_NAMES_FILTER: ${{ inputs.dir_names_filter }}
+        LOCALE: ${{ inputs.locale }}
+      run: |
+        echo "::group::Validate documentation directories"
+        # Guard: fail before any S3 change if a doc directory matching a dirName
+        # (from the filter list or from the bucket dirNames.json) is missing at
+        # least one of README.md or SUMMARY.md.
+
+        # Fetch the published dirNames list from the bucket.
+        if [[ -n "$LOCALE" ]]; then
+          S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${LOCALE}/${S3_DIRNAMES_JSON_PATH}"
+        else
+          S3_DIRNAMES="s3://devportal-${ENV_SHORT}-website-static-content/${S3_DIRNAMES_JSON_PATH}"
+        fi
+        aws s3 cp "$S3_DIRNAMES" bucket-dirNames.json || echo '{"dirNames": []}' > bucket-dirNames.json
+
+        # Collect candidate directories from the bucket dirNames.json...
+        CANDIDATES=$(jq -r '.dirNames[]' bucket-dirNames.json 2>/dev/null | sort -u)
+
+        # ...and from the filter list, when provided.
+        if [[ -n "$DIR_NAMES_FILTER" ]]; then
+          IFS=',' read -ra FILTER_DIRS <<< "$DIR_NAMES_FILTER"
+          for d in "${FILTER_DIRS[@]}"; do
+            d=$(echo "$d" | xargs)
+            [[ -n "$d" ]] && CANDIDATES=$(printf '%s\n%s\n' "$CANDIDATES" "$d")
+          done
+        fi
+        CANDIDATES=$(echo "$CANDIDATES" | sort -u)
+
+        INVALID_DIRS=()
+        while IFS= read -r dir; do
+          [[ -z "$dir" ]] && continue
+          # Only validate directories that actually exist in the checked-out docs.
+          if [[ -d "docs/$dir" ]]; then
+            if [[ ! -f "docs/$dir/README.md" || ! -f "docs/$dir/SUMMARY.md" ]]; then
+              INVALID_DIRS+=("$dir")
+            fi
+          fi
+        done <<< "$CANDIDATES"
+
+        if [[ ${#INVALID_DIRS[@]} -gt 0 ]]; then
+          echo "::error::Found documentation directories missing README.md or SUMMARY.md:"
+          for dir in "${INVALID_DIRS[@]}"; do
+            echo "::error:: - docs/$dir"
+          done
+          echo "::endgroup::"
+          exit 1
+        fi
+
+        echo "All candidate documentation directories contain both README.md and SUMMARY.md."
+        echo "::endgroup::"
+
     - name: Generate all metadata
       shell: bash
       env:

--- a/.github/actions/sync-gitbook-docs/action.yaml
+++ b/.github/actions/sync-gitbook-docs/action.yaml
@@ -187,8 +187,12 @@ runs:
           aws s3 cp "$S3_DIRNAMES" bucket-dirNames.json || echo '{"dirNames": []}' > bucket-dirNames.json
           CANDIDATES=$(jq -r '.dirNames[]' bucket-dirNames.json 2>/dev/null)
         fi
-        CANDIDATES=$(echo "$CANDIDATES" | sort -u)
+        CANDIDATES=$(printf '%s\n' "$CANDIDATES" | sed '/^$/d' | sort -u)
 
+        if [[ -z "$CANDIDATES" ]]; then
+          # No published list available => later steps will sync all docs, so validate all top-level docs directories.
+          CANDIDATES=$(find docs -mindepth 1 -maxdepth 1 -type d ! -name '.*' -printf '%f\n' | sort -u)
+        fi
         INVALID_DIRS=()
         while IFS= read -r dir; do
           [[ -z "$dir" ]] && continue


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This pull request adds a validation step to the GitHub Actions workflow for syncing GitBook documentation. The new step ensures that all candidate documentation directories contain both a `README.md` and a `SUMMARY.md` file before any changes are made to S3, preventing incomplete documentation from being published.

#### List of Changes
<!--- Describe your changes in detail -->
**Documentation validation improvements:**

* Added a new workflow step in `.github/actions/sync-gitbook-docs/action.yaml` that checks each candidate documentation directory (either from a provided filter list or from the S3 `dirNames.json`) to ensure both `README.md` and `SUMMARY.md` exist. If any are missing, the workflow fails early with an error message.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
