### PR TITLE
[DEV-4476] - Reduce paragraph bottom margin in case histories

### DIFF
--- a/.changeset/flat-books-trade.md
+++ b/.changeset/flat-books-trade.md
@@ -1,0 +1,5 @@
+---
+"nextjs-website": patch
+---
+
+Reduce paragraph bottom margin in case histories

--- a/apps/nextjs-website/src/components/molecules/BlocksRendererClient/BlocksRendererClient.tsx
+++ b/apps/nextjs-website/src/components/molecules/BlocksRendererClient/BlocksRendererClient.tsx
@@ -63,10 +63,12 @@ const BlocksRendererClient = ({
         ),
         paragraph: ({ children }) => (
           <Typography
-            marginBottom={5}
             variant='body1'
             color={textColor}
-            sx={paragraphSx}
+            sx={{
+              marginBottom: 5,
+              ...paragraphSx,
+            }}
           >
             {children}
           </Typography>

--- a/apps/nextjs-website/src/components/molecules/PartRenderer/PartRenderer.tsx
+++ b/apps/nextjs-website/src/components/molecules/PartRenderer/PartRenderer.tsx
@@ -10,17 +10,12 @@ import BlocksRendererPart from '@/components/organisms/BlocksRendererPart/Blocks
 import Quote from '@/components/atoms/Quote/Quote';
 import CkEditorPart from '../CkEditorPart/CkEditorPart';
 import MarkdownPart from '@/components/molecules/MarkdownPart/MarkdownPart';
-import { SxProps, Theme } from '@mui/material';
 
 type PartRendererProps = {
   part: Part;
-  paragraphSx?: SxProps<Theme>;
 };
 
-const PartRenderer = ({
-  part,
-  paragraphSx,
-}: PartRendererProps): ReactNode | null => {
+const PartRenderer = ({ part }: PartRendererProps): ReactNode | null => {
   switch (part.component) {
     case 'alert':
       return <AlertPart {...part} />;
@@ -29,7 +24,7 @@ const PartRenderer = ({
     case 'apiTester':
       return <ApiTesterPart {...part} />;
     case 'blockRenderer':
-      return <BlocksRendererPart {...part} paragraphSx={paragraphSx} />;
+      return <BlocksRendererPart {...part} />;
     case 'codeBlock':
       return <CodeBlockPart {...part} />;
     case 'innerHTMLLazyLoaded':

--- a/apps/nextjs-website/src/components/molecules/PartRenderer/PartRenderer.tsx
+++ b/apps/nextjs-website/src/components/molecules/PartRenderer/PartRenderer.tsx
@@ -10,12 +10,17 @@ import BlocksRendererPart from '@/components/organisms/BlocksRendererPart/Blocks
 import Quote from '@/components/atoms/Quote/Quote';
 import CkEditorPart from '../CkEditorPart/CkEditorPart';
 import MarkdownPart from '@/components/molecules/MarkdownPart/MarkdownPart';
+import { SxProps, Theme } from '@mui/material';
 
 type PartRendererProps = {
   part: Part;
+  paragraphSx?: SxProps<Theme>;
 };
 
-const PartRenderer = ({ part }: PartRendererProps): ReactNode | null => {
+const PartRenderer = ({
+  part,
+  paragraphSx,
+}: PartRendererProps): ReactNode | null => {
   switch (part.component) {
     case 'alert':
       return <AlertPart {...part} />;
@@ -24,7 +29,7 @@ const PartRenderer = ({ part }: PartRendererProps): ReactNode | null => {
     case 'apiTester':
       return <ApiTesterPart {...part} />;
     case 'blockRenderer':
-      return <BlocksRendererPart {...part} />;
+      return <BlocksRendererPart {...part} paragraphSx={paragraphSx} />;
     case 'codeBlock':
       return <CodeBlockPart {...part} />;
     case 'innerHTMLLazyLoaded':

--- a/apps/nextjs-website/src/components/organisms/BlocksRendererPart/BlocksRendererPart.tsx
+++ b/apps/nextjs-website/src/components/organisms/BlocksRendererPart/BlocksRendererPart.tsx
@@ -1,15 +1,18 @@
 'use client';
 import React from 'react';
-import { Box } from '@mui/material';
+import { Box, SxProps, Theme } from '@mui/material';
 import BlocksRendererClient from '@/components/molecules/BlocksRendererClient/BlocksRendererClient';
 import { BlocksContent } from '@strapi/blocks-react-renderer';
 
-export type BlocksRendererPartProps = { readonly html: BlocksContent };
+export type BlocksRendererPartProps = {
+  readonly html: BlocksContent;
+  readonly paragraphSx?: SxProps<Theme>;
+};
 
-const BlocksRendererPart = ({ html }: BlocksRendererPartProps) => {
+const BlocksRendererPart = ({ html, paragraphSx }: BlocksRendererPartProps) => {
   return (
     <Box component='div' mt={2}>
-      <BlocksRendererClient content={html} />
+      <BlocksRendererClient content={html} paragraphSx={paragraphSx} />
     </Box>
   );
 };

--- a/apps/nextjs-website/src/components/templates/CaseHistoryTemplate/CaseHistoryPageTemplate.tsx
+++ b/apps/nextjs-website/src/components/templates/CaseHistoryTemplate/CaseHistoryPageTemplate.tsx
@@ -87,7 +87,7 @@ const CaseHistoryPageTemplate = ({
       {parts.map((part: Part, index: number) =>
         part.component !== 'quote' ? (
           <EContainer key={index}>
-            <PartRenderer part={part} />
+            <PartRenderer part={part} paragraphSx={{ marginBottom: '15px' }} />
           </EContainer>
         ) : (
           <Box key={index}>

--- a/apps/nextjs-website/src/components/templates/CaseHistoryTemplate/CaseHistoryPageTemplate.tsx
+++ b/apps/nextjs-website/src/components/templates/CaseHistoryTemplate/CaseHistoryPageTemplate.tsx
@@ -87,7 +87,14 @@ const CaseHistoryPageTemplate = ({
       {parts.map((part: Part, index: number) =>
         part.component !== 'quote' ? (
           <EContainer key={index}>
-            <PartRenderer part={part} paragraphSx={{ marginBottom: '15px' }} />
+            <PartRenderer
+              part={{
+                ...part,
+                ...(part.component === 'blockRenderer' && {
+                  paragraphSx: { marginBottom: '15px' },
+                }),
+              }}
+            />
           </EContainer>
         ) : (
           <Box key={index}>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Reduced paragraph bottom margin in Case History pages.
- Applied the change only to Case History rendering, leaving the default behaviour unchanged for other pages.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Case History pages currently have excessive spacing between paragraphs. This change reduces the bottom margin from 40px to 15px.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran locally in Dev

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
